### PR TITLE
VBID-3552 ad cache for playing ads when offline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ build: deps
 
 clean:
 	@find . -maxdepth 1 -iname '$(PROJECT_NAME)-*.zip' -print0 | xargs -0 rm -f
+	@rm -rf lib/*
 
 copy_manifest:
 	@cp manifest.json build/manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "vistar-html5player",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "index.html"
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "connect":             "2.25.7",
     "connect-livereload":  "0.4.0",
     "domino":              "1.0.17",
-    "gulp":                "3.8.x",
+    "gulp":                "3.8.8",
     "gulp-browserify":     "0.5.x",
     "gulp-cjsx":           "2.0.x",
     "gulp-coffee":         "2.2.0",
@@ -42,10 +42,10 @@
     "gulp-livereload":     "2.1.0",
     "gulp-mocha":          "1.1.0",
     "gulp-util":           "2.2.x",
-    "honk-test-net":       "0.1.0",
     "mocha":               "^1",
     "serve-static":        "1.5.3",
     "sinon":               "1.12.2",
-    "sinon-chai":          "2.6.0"
+    "sinon-chai":          "2.6.0",
+    "through2":            "0.6.3"
   }
 }

--- a/src/ad_cache.coffee
+++ b/src/ad_cache.coffee
@@ -1,0 +1,103 @@
+inject              = require 'honk-di'
+Logger              = require './logger'
+net                 = window?.Cortex?.net
+{Ajax, XMLHttpAjax} = require './ajax'
+{Transform}         = require('stream')
+
+now = -> (new Date).getTime()
+
+# every 15 minutes
+cacheClearInterval = 15 * 60 * 1000
+# default ttl is 6 hours:  it's important that this number isn't any shorter
+# than the maximum amount of time an ad will sit in the pipeline since there's
+# no safeguard to ensure the url isn't expired before it gets to the player
+defaultTtl         = 6 * 60 * 60 * 1000
+
+sum = (list, acc=0) ->
+  if list?.length is 0
+    acc
+  else
+    [head, tail...] = list
+    sum(tail, head + acc)
+
+
+class AdCache extends Transform
+  config:          inject 'config'
+  http:            inject Ajax
+  log:             inject Logger
+  sizeInBytes:     0
+
+  constructor: (@store={}, @ttl=defaultTtl) ->
+    @sizeInBytes = sum(o.sizeInBytes for url, o of @store)
+    setInterval @expire, cacheClearInterval
+    super(objectMode: true, highWaterMark: 60)
+
+  fetchPathByAssetURL: (url, cb) ->
+    # call callback with either a local path (from Cortex) or an objectURL from
+    # URL.createObjectURL
+    success = (response) =>
+      @store[url] =
+        cachedAt:     now()
+        lastSeenAt:   now()
+        dataUrl:      URL.createObjectURL(response)
+        sizeInBytes:  response.size
+        mimeType:     response.type
+
+      @sizeInBytes  = @sizeInBytes + response.size
+      cb(@store[url].dataUrl)
+
+    if not @store[url]
+      request = @http.request
+        responseType:  'blob'
+        url:           url
+      request.then(success)
+    else
+      @store[url].lastSeenAt = now()
+      cb(@store[url].dataUrl)
+
+  expire: =>
+    @log.write name: 'AdCache', message:
+      """
+      starting clearing store #{JSON.stringify(@store)}
+      """
+    started = now()
+    for url, entry of @store
+      diff = (started - entry.lastSeenAt)
+      if diff > @ttl
+        @log.write name: 'AdCache', message:
+          """
+          removing cached asset for #{url}, diff #{diff}
+          """
+        @sizeInBytes = @sizeInBytes - entry.sizeInBytes
+        delete @store[url]
+        URL.revokeObjectURL(entry.dataUrl)
+
+  _transform: (ad, encoding, callback) ->
+    url = ad.asset_url
+
+    @log.write name: 'AdCache', message:
+      """
+      received #{url}, read length #{@_readableState.buffer.length}
+      write length #{@_writableState.buffer.length}
+      """
+
+    if net?.download
+      # TODO:  Hamza says the api for this will change from returning a promise
+      # to the usual node.js (err, callback) -> style.  keep an eye out for that
+      # and change this when applicable
+      net.download(url, cache: @ttl).then (path) =>
+        ad.asset_url = path
+        @push(ad)
+        callback()
+    else
+      @fetchPathByAssetURL url, (path) =>
+        ad.asset_url = path
+        @log.write name: 'AdCache', message:
+          """
+          cache entry for #{url} exists?: #{@store[url]?}
+          """
+        @push(ad)
+        callback()
+
+
+module.exports = AdCache

--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -24,9 +24,13 @@ class XMLHttpAjax extends Ajax
     url    = options.url
 
     xhr = new window.XMLHttpRequest()
+    if options.responseType
+      xhr.responseType = options.responseType
 
     xhr.onload = (e) =>
       if xhr.status is 200
+        if options.responseType == 'blob'
+          return deferred.resolve(xhr.response)
         switch options.dataType
           when 'json' then deferred.resolve(JSON.parse(xhr.responseText))
           else deferred.resolve(xhr.responseText)

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -1,8 +1,9 @@
 inject              = require 'honk-di'
+AdCache             = require './ad_cache'
 AdStream            = require './ad_stream'
-{Ajax, XMLHttpAjax} = require './ajax'
 Player              = require './player'
 ProofOfPlay         = require './proof_of_play'
+{Ajax, XMLHttpAjax} = require './ajax'
 
 
 window?.Vistar = (config) ->
@@ -18,21 +19,20 @@ window?.Vistar = (config) ->
         apiKey:            '58b68728-11d4-41ed-964a-95dca7b59abd'
         networkId:         'Ex-f6cCtRcydns8mcQqFWQ'
         debug:             true
-        width:             1024
-        height:            768
+        width:             1280
+        height:            720
         allowAudio:        true
         directConnection:  false
         deviceId:          'YOUR_DEVICE_ID'
         venueId:           'YOUR_VENUE_ID'
         latitude:          39.9859241
         longitude:         -75.1299363
-        queueSize:         12
-        mimeTypes:         ['video/webm']
+        queueSize:         10
         displayArea: [
           {
             id:               'display-0'
-            width:            1024
-            height:           768
+            width:             1280
+            height:            720
             allow_audio:      false
             cpm_floor_cents:  90
           }
@@ -40,8 +40,23 @@ window?.Vistar = (config) ->
 
   injector = new inject.Injector(new Binder)
 
+  store = {}
+
   ads    = injector.getInstance AdStream
+  cache  = injector.getInstance AdCache, store
   player = injector.getInstance Player
   pop    = injector.getInstance ProofOfPlay
 
-  ads.pipe(player).pipe(pop)
+  # this exists only so one can inspect the different components while it's
+  # running
+  window.__vistarplayer =
+    ads:     ads
+    cache:   cache
+    player:  player
+    pop:     pop
+    store:   store
+
+  ads
+    .pipe(cache)
+    .pipe(player)
+    .pipe(pop)

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -14,7 +14,7 @@ class Player extends Transform
   _currentAd:  null
 
   constructor: ->
-    super(highWaterMark: @config.queueSize, objectMode: true)
+    super(highWaterMark: 0, objectMode: true)
     @video.addEventListener 'ended', @_videoFinished
     @video.addEventListener 'play', =>
       @log.write name: 'Player', message: 'video playing'
@@ -34,19 +34,23 @@ class Player extends Transform
       callback(null, ad)
 
     @image.setAttribute 'src', advertisement.asset_url
+
     @log.write name: 'Player', message: 'image playing'
     @image.className = ''
 
     @_timeoutId = setTimeout finished, duration
 
-  playVideo: (advertisement) ->
+  playVideo: (advertisement, callback) ->
     @hide()
-    duration = advertisement.length_in_milliseconds
     @video.setAttribute 'src', advertisement.asset_url
 
   _transform: (advertisement, encoding, callback) ->
     @log.write name: 'Player', message:
-      "receiving advertisement, buf length #{@_writableState.buffer.length}"
+      """
+      receiving advertisement:
+      writable buf length #{@_writableState.buffer.length}"
+      readable buf length #{@_readableState.buffer.length}"
+      """
     @_currentAd = advertisement
     mimeType    = advertisement.mime_type
     if advertisement.mime_type.match(/^image/)

--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -1,46 +1,54 @@
 inject      = require 'honk-di'
-{Ajax}      = require './ajax'
 Logger      = require './logger'
+{Ajax}      = require './ajax'
 {Transform} = require('stream')
 
 
 class ProofOfPlay extends Transform
-  @scope: 'SINGLETON'
-
   http:    inject Ajax
   config:  inject 'config'
   log:     inject Logger
 
   constructor: ->
-    super(objectMode: true)
+    super(objectMode: true, highWaterMark: 100)
 
   expire: (ad) ->
     @log.write name: 'ProofOfPlay', message: 'expiring', meta: ad
     url = ad.expiration_url
-    req = @http.request
-      type: 'GET'
-      url:  url
-    req.then (response) -> JSON.parse(response)
+    @http.request
+      type:      'GET'
+      url:       url
+      dataType:  'json'
 
   confirm: (ad) ->
     @log.write name: 'ProofOfPlay', message: 'confirming', meta: ad
     url = ad.proof_of_play_url
-    req = @http.request
-      type: 'POST'
-      url:  url
+    @http.request
+      type:      'POST'
+      url:       url
+      dataType:  'json'
       data: JSON.stringify(display_time: ad.display_time)
-    req.then (response) -> JSON.parse(response)
 
   _transform: (ad, encoding, callback) ->
     if @_wasDisplayed(ad)
-      @confirm(ad).then (response) ->
-        callback(null, response)
+      @confirm(ad).then (response) =>
+        @_process(response, callback)
     else
-      @expire(ad).then (response) ->
-        callback(null, response)
+      @expire(ad).then (response) =>
+        @_process(response, callback)
 
   _wasDisplayed: (ad) ->
     ad.html5player?.was_played
+
+  _process: (response, cb) ->
+    # optionally pass PoP response on down the pipe.  if there are no consumers
+    # of these stream, drop it on the floor.  This needs to happen because if
+    # we fill up our _readableState.buffer to the highWaterMark, we'll stop
+    # making PoP requests
+    if @_readableState.pipesCount > 0
+      cb(null, response)
+    else
+      cb()
 
 
 module.exports = ProofOfPlay

--- a/test/ad_cache_spec.coffee
+++ b/test/ad_cache_spec.coffee
@@ -1,0 +1,206 @@
+require './test_case'
+AdCache  = require '../src/ad_cache'
+sinon    = require 'sinon'
+through2 = require 'through2'
+{Ajax}   = require '../src/ajax'
+{expect} = require 'chai'
+
+
+describe 'AdCache', ->
+
+  beforeEach ->
+    @http = @injector.getInstance Ajax
+    @getAd = =>
+      JSON.parse(JSON.stringify(@fixtures.adResponse.advertisement[0]))
+
+  it 'should have a sizeInBytes', ->
+    pipe = @injector.getInstance AdCache
+    expect(pipe.sizeInBytes).to.equal 0
+
+  it 'should set if existing store has sizeInBytes on objects', ->
+    store =
+      'http://honk.example':
+        cachedAt:     (new Date).getTime()
+        dataUrl:      'blob://somethingsomething'
+        sizeInBytes:  5000
+        mimeType:     'image/png'
+    pipe = @injector.getInstance AdCache, store
+    expect(pipe.sizeInBytes).to.equal 5000
+
+  context 'when asset is not cached', ->
+
+    beforeEach ->
+      @now   = 142460040000
+      @clock = sinon.useFakeTimers(@now)
+      @cache = @injector.getInstance AdCache
+      URL.createObjectURL.returns('blob:someblob')
+
+    afterEach ->
+      @clock.restore()
+
+    it 'should make request with responseType "blob"', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        expect(req.responseType).to.equal 'blob'
+        done()
+
+      @cache.write(ad)
+
+    it 'should add to the cache with cachedAt timestamp', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        resolve response: sinon.stub()
+
+      @cache.pipe through2.obj =>
+        expect(@cache.store[assetUrl].cachedAt).to.equal @now
+        done()
+
+      @cache.write(ad)
+
+    it 'should put dataUrl from URL.createObjectURL in cache', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        resolve response: sinon.stub()
+
+      @cache.pipe through2.obj =>
+        expect(@cache.store[assetUrl].dataUrl).to.equal 'blob:someblob'
+        done()
+
+      @cache.write(ad)
+
+    it 'should add to the cache with sizeInBytes', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        resolve size: 1234
+
+      @cache.pipe through2.obj =>
+        expect(@cache.store[assetUrl].sizeInBytes).to.equal 1234
+        done()
+
+      @cache.write(ad)
+
+    it 'should add to the cache with mimeType', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        resolve
+          size: 1234
+          type: 'image/jpeg'
+
+      @cache.pipe through2.obj =>
+        expect(@cache.store[assetUrl].mimeType).to.equal 'image/jpeg'
+        done()
+
+      @cache.write(ad)
+
+    it 'should increase sizeInBytes variable', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        resolve
+          size: 2000
+          type: 'image/jpeg'
+
+      @cache.pipe through2.obj =>
+        expect(@cache.sizeInBytes).to.equal 4000
+        done()
+
+      @cache.write(ad)
+      @cache.write(ad)
+
+    it 'should change the `ad.asset_url` to the dataUrl', (done) ->
+      ad = @getAd()
+      assetUrl = ad.asset_url
+      @http.match url: assetUrl, type: 'GET', (req, resolve) ->
+        resolve
+          size: 2000
+          type: 'image/jpeg'
+
+      @cache.pipe through2.obj (adWithDataUrl) ->
+        expect(adWithDataUrl.asset_url).to.equal 'blob:someblob'
+        done()
+
+      @cache.write(ad)
+
+  context 'when asset is already cached', ->
+
+    beforeEach ->
+      @ad = @getAd()
+      @assetUrl = @ad.asset_url
+      @store = {}
+      @store[@assetUrl] =
+        cachedAt:     (new Date).getTime()
+        lastSeenAt:   (new Date).getTime()
+        dataUrl:      'blob:somethingsomething'
+        sizeInBytes:  5000
+        mimeType:     'image/png'
+      @cache = @injector.getInstance AdCache, @store
+
+      @now   = 142460040000
+      @clock = sinon.useFakeTimers(@now)
+
+    afterEach ->
+      @clock.restore()
+
+    it 'should update the lastSeenAt time of the cached asset', (done) ->
+      @cache.pipe through2.obj =>
+        cacheEntry = @store[@assetUrl]
+        expect(cacheEntry).to.exist
+        expect(cacheEntry.lastSeenAt).to.equal @now
+        done()
+
+      @cache.write(@ad)
+
+    it 'should emit the ad with the asset_url as the dataUrl', (done) ->
+      @cache.pipe through2.obj (adWithDataUrl) ->
+        expect(adWithDataUrl.asset_url).to.equal 'blob:somethingsomething'
+        done()
+
+      @cache.write(@ad)
+
+  context 'when expire runs', ->
+
+    beforeEach ->
+      @clock = sinon.useFakeTimers(1424122265803)
+      @store = {}
+      # set lastSeenAt to 7 hours ago to see if it will expire
+      @store['http://asset.example.com/1.jpg'] =
+        lastSeenAt:     (new Date).getTime() - (9 * 60 * 60 * 1000)
+        lastSeenAt:     (new Date).getTime() - (7 * 60 * 60 * 1000)
+        dataUrl:      'blob://somethingsomething1'
+        sizeInBytes:  5000
+        mimeType:     'image/png'
+      @store['http://asset.example.com/2.webm'] =
+        cachedAt:     (new Date).getTime()
+        lastSeenAt:     (new Date).getTime() - 1000
+        dataUrl:      'blob://somethingsomething2'
+        sizeInBytes:  5000
+        mimeType:     'video/webm'
+
+      @cache = @injector.getInstance AdCache, @store
+
+    afterEach ->
+      @clock.restore()
+
+    it 'should remove expired assets from the store every 15 minutes', ->
+      @clock.tick(15 * 60 * 1000)
+
+      expect(@store['http://asset.example.com/1.jpg']).to.not.exist
+      expect(@store['http://asset.example.com/2.webm']).to.exist
+
+    context 'and assets should expire', ->
+
+      it 'should call URL.revokeObjectURL with the dataUrl', ->
+        @clock.tick(15 * 60 * 1000)
+        expect(URL.revokeObjectURL).to.have.been.calledOnce
+        expect(URL.revokeObjectURL).to.have.been
+          .calledWith 'blob://somethingsomething1'
+
+      it 'should decrease the sizeInBytes var', ->
+        expect(@cache.sizeInBytes).to.equal 10000
+        @clock.tick(15 * 60 * 1000)
+        expect(@cache.sizeInBytes).to.equal 5000

--- a/test/ad_request_spec.coffee
+++ b/test/ad_request_spec.coffee
@@ -2,6 +2,7 @@ require './test_case'
 {expect} = require 'chai'
 
 AdRequest = require '../src/ad_request'
+{Ajax}    = require '../src/ajax'
 
 
 describe 'AdRequest', ->
@@ -9,6 +10,7 @@ describe 'AdRequest', ->
   beforeEach ->
     @config  = @injector.getInstance 'config'
     @request = @injector.getInstance AdRequest
+    @http    = @injector.getInstance Ajax
 
   it 'should inject a config', ->
     expect(@request.config).to.equal @injector.getInstance 'config'
@@ -19,9 +21,8 @@ describe 'AdRequest', ->
 
   it 'should make a POST request to the get_ad endpoint', (done) ->
     url = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
-    @server.when 'POST', url, (req) =>
-      status: 200
-      body:   JSON.stringify(@fixtures.adResponse)
+    @http.match url: url, type: 'POST', (req, resolve) ->
+      done()
 
     @request.fetch().then -> done()
 
@@ -85,37 +86,32 @@ describe 'AdRequest', ->
 
     it 'should include mime types in display_area supported_media', (done) ->
       url = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
-      @server.when 'POST', url, (req) =>
-        requestBody = JSON.parse(req.requestText)
+      @http.match url: url, type: 'POST', (req, resolve) ->
+        requestBody = JSON.parse(req.data)
         mimeTypes = requestBody.display_area[0].supported_media
         expect(mimeTypes).to.exist
         expect(mimeTypes).to.include 'image/png'
         expect(mimeTypes).to.include 'image/jpeg'
         expect(mimeTypes).to.include 'image/gif'
         done()
-        status: 200
-        body:   JSON.stringify(@fixtures.adResponse)
 
       @request.fetch()
 
-    it 'should POST an add request of the expected format', (done) ->
+    it 'should POST an ad request of the expected format', (done) ->
       url = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
-      @server.when 'POST', url, (req) =>
-        requestBody = JSON.parse(req.requestText)
+      @http.match url: url, type: 'POST', (req, resolve) ->
+        requestBody = JSON.parse(req.data)
         expect(requestBody.network_id).to.exist
         expect(requestBody.api_key).to.exist
         expect(requestBody.display_area).to.have.length 1
         done()
-        status: 200
-        body:   JSON.stringify(@fixtures.adResponse)
 
       @request.fetch()
 
     it 'should resolve with the ad response', (done) ->
       url = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
-      @server.when 'POST', url, (req) =>
-        status: 200
-        body:   JSON.stringify(@fixtures.adResponse)
+      @http.match url: url, type: 'POST', (req, resolve) =>
+        resolve @fixtures.adResponse
 
       success = (response) ->
         expect(response).to.be.an.instanceOf Object

--- a/test/ad_stream_spec.coffee
+++ b/test/ad_stream_spec.coffee
@@ -2,14 +2,17 @@ require './test_case'
 sinon    = require 'sinon'
 {expect} = require 'chai'
 
-AdStream  = require '../src/ad_stream'
 AdRequest = require '../src/ad_request'
+AdStream  = require '../src/ad_stream'
+{Ajax}    = require '../src/ajax'
+through2  = require 'through2'
 
 
 describe 'AdStream', ->
 
   beforeEach ->
-    @ads = @injector.getInstance AdStream
+    @ads  = @injector.getInstance AdStream
+    @http = @injector.getInstance Ajax
 
   it 'should be a readable stream', ->
     expect(@ads).to.respondTo 'read'
@@ -24,16 +27,18 @@ describe 'AdStream', ->
   context 'on successful ad request', ->
 
     beforeEach ->
-      url = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
-      id  = 0
-      @server.when 'POST', url, (req) =>
+      url     = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
+      id      = 0
+
+      @http.match url: url, type: 'POST', (req, resolve) =>
         ads = for ad in @fixtures.adResponse.advertisement
+          ad = @clone(ad)
           ad.id = "id-#{++id}"
           ad
-        status: 200
-        body:   JSON.stringify(advertisement: ads)
+        resolve advertisement: ads
 
     it 'should return an ad for each call to `read`', ->
+      console.log
       ad1 = @ads.read()
       ad2 = @ads.read()
 
@@ -54,9 +59,8 @@ describe 'AdStream', ->
     beforeEach ->
       url = 'http://test.api.vistarmedia.com/api/v1/get_ad/json'
       id  = 0
-      @server.when 'POST', url, (req) =>
-        status: 200
-        body:   JSON.stringify([])
+      @http.match url: url, type: 'POST', (req, resolve) =>
+        resolve advertisement: []
 
     it.skip 'should call `read` again after 15 seconds', ->
       # TODO:  figure out why fake timers don't work here

--- a/test/test_ajax.coffee
+++ b/test/test_ajax.coffee
@@ -1,0 +1,27 @@
+{Ajax} = require '../src/ajax'
+
+
+class TestAjax extends Ajax
+
+  constructor: ->
+    super
+    @_handlers = []
+
+  _request: (options, deferred) ->
+    for [match, handler] in @_handlers
+      match = true
+      for k, v of match
+        if options[k] isnt v
+          match = false
+          continue
+      if match
+        handler(options, deferred.resolve, deferred.reject)
+      else
+        message "#{options.type} #{options.url} not found"
+        deferred.reject(status: 404, message: message)
+
+  match: (match, handler) ->
+    @_handlers.push([match, handler])
+
+
+module.exports = TestAjax

--- a/test/test_case.coffee
+++ b/test/test_case.coffee
@@ -1,16 +1,17 @@
 require './test_dom'
 inject = require 'honk-di'
 chai   = require 'chai'
-
-{Ajax, XMLHttpAjax} = require '../src/ajax'
-
 chai.use(require('sinon-chai'))
+
+{Ajax}   = require '../src/ajax'
+TestAjax = require './test_ajax'
+
 
 
 beforeEach ->
   class Binder extends inject.Binder
     configure: ->
-      @bind(Ajax).to(XMLHttpAjax)
+      @bind(Ajax).to(TestAjax)
       @bindConstant('navigator').to
         mimeTypes: [
           type: 'text/x-navigator-mime-type'
@@ -44,6 +45,9 @@ beforeEach ->
         ]
 
   @injector = new inject.Injector(new Binder)
+
+  @clone = (obj) -> JSON.parse(JSON.stringify(obj))
+
   @fixtures =
     expireResponse:
       impressions:  0.0
@@ -97,6 +101,3 @@ beforeEach ->
           creative_category:       '10013'
         },
       ]
-
-afterEach ->
-  @server.stop()

--- a/test/test_dom.coffee
+++ b/test/test_dom.coffee
@@ -14,6 +14,7 @@ _initDocument = ->
   global.Blob                 = stub()
   global.URL                  = stub()
   global.URL.createObjectURL  = stub()
+  global.URL.revokeObjectURL  = stub()
 
   player = document.createElement('div')
   video  = document.createElement('video')
@@ -35,12 +36,6 @@ _destroyWindow = ->
 # with DOM elements.
 beforeEach ->
   window  = _initDocument()
-  # requiring honk-test-net down here because if it's required before a
-  # global.document exists, it'll require 'jsdom' and set one
-  {HttpServer} = require 'honk-test-net/lib/index'
-  @server = new HttpServer(window)
-  @server.start()
-
   React     = require('react')
   TestUtils = require('react/addons').addons.TestUtils
 
@@ -71,7 +66,6 @@ beforeEach ->
 
 # Nuke the global state of window/document/navigator
 afterEach ->
-  @server.stop()
   React = require('react')
   for node in @_nodes
     React.unmountComponentAtNode(node)


### PR DESCRIPTION
- add an ad cache stream: uses Cortex API if available, otherwise cache
  assets by url using `URL.createObjectURL`
- fix a bug with the ProofOfPlay stream where it would stop sending PoP
  requests when we hit the highWaterMark of that Stream, which would be
  always since there was no consumer for it.  Add a check that
  if _readableState.pipesCount > 0, we'll throw it on the readable
  buffer.  Otherwise drop it on the floor and continue
- give the AdStream a 'lowWaterMark' - when its buffer is less than half
  of the highWaterMark, make some more ad requests
- remove honk-test-net in favor of using injected TestAjax fella, update
  tests to use that guy