### PR TITLE
Attempt to not show the same ad back to back

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -1,8 +1,8 @@
 inject              = require 'honk-di'
-AdCache             = require './ad_cache'
-AdStream            = require './ad_stream'
+
 Player              = require './player'
 ProofOfPlay         = require './proof_of_play'
+VariedAdStream      = require './varied_ad_stream'
 {Ajax, XMLHttpAjax} = require './ajax'
 
 defaultConfig = {}
@@ -53,8 +53,7 @@ window?.Vistar = ->
 
   store  = injector.getInstance 'download-cache'
 
-  ads    = injector.getInstance AdStream
-  cache  = injector.getInstance AdCache
+  ads    = injector.getInstance VariedAdStream
   player = injector.getInstance Player
   pop    = injector.getInstance ProofOfPlay
 
@@ -68,6 +67,5 @@ window?.Vistar = ->
     store:   store
 
   ads
-    .pipe(cache)
     .pipe(player)
     .pipe(pop)

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -61,7 +61,6 @@ window?.Vistar = ->
   # running
   window.__vistarplayer =
     ads:     ads
-    cache:   cache
     player:  player
     pop:     pop
     store:   store

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -1,0 +1,49 @@
+deferred = require 'deferred'
+inject   = require 'honk-di'
+
+AdRequest     = require './ad_request'
+Logger        = require './logger'
+VarietyStream = require './variety_stream'
+{Download}    = require './ajax'
+
+
+assetTTL = 6 * 60 * 60 * 1000
+
+
+class VariedAdStream extends VarietyStream
+  _adRequest:  inject AdRequest
+  _config:     inject 'config'
+  _download:   inject Download
+  _log:        inject Logger
+
+  constructor: ->
+    super(@_config.queueSize or 16)
+
+  # The "unique" identity (in terms of adjacency) for an advertisement will be
+  # its creative id. The VarietyStream will attempt to not show the same ads
+  # back to back.
+  _identify: (ad) ->
+    ad.creative_id
+
+  _next: (callback) ->
+
+    success = (response) =>
+      ads = response?.advertisement or []
+      @_log.write name: 'AdStream', message: "Returned #{ads.length} ads"
+
+      downloads = for ad in ads
+        @_download.request url: ad.asset_url, ttl: assetTTL
+
+      deferred(downloads)
+        .then -> callback(ads)
+        .catch -> callback([])
+        .done()
+
+    error = (e) =>
+      @_log.write name: 'AdStream', message: "request error #{JSON.stringify(e)}"
+      callback([])
+
+    @_adRequest.fetch().then(success).catch(error).done()
+
+
+module.exports = VariedAdStream

--- a/src/variety_queue.coffee
+++ b/src/variety_queue.coffee
@@ -1,0 +1,48 @@
+
+identity = (x) -> String(x)
+
+
+# A roughly FIFO queue that tries to maximize variety in the items pop'd. That
+# is, if possible, it will try to minimize adjacency. This is a relatively simple
+# operation that does not look ahead -- if it contains items [A, B, B], it may
+# well yield A first, even though yielding B will provide better overall
+# results.
+#
+# This never guarantees that it will not give the same item twice.
+class VarietyQueue
+
+  constructor: (@identify=identity) ->
+    @_items = []
+    @_timeSinceLastPop = {}
+
+  push: (item) ->
+    itemId = @identify(item)
+    if itemId not of @_timeSinceLastPop
+      @_timeSinceLastPop[itemId] = Object.keys(@_timeSinceLastPop).length
+
+    @_items.push(item)
+
+  pop: ->
+    @_items.sort (a, b) =>
+      idA = @identify(a)
+      idB = @identify(b)
+      @_timeSinceLastPop[idB] - @_timeSinceLastPop[idA]
+
+    res = @_items.shift()
+    unless res? then return
+
+    resId = @identify(res)
+    for id, count of @_timeSinceLastPop
+
+      if id is resId
+        @_timeSinceLastPop[id] = 0
+      else
+        @_timeSinceLastPop[id]++
+
+    res
+
+  size: ->
+    @_items.length
+
+
+module.exports = VarietyQueue

--- a/src/variety_stream.coffee
+++ b/src/variety_stream.coffee
@@ -1,0 +1,66 @@
+VarietyQueue = require './variety_queue'
+
+
+# A pseudo-stream which can feed input (via a pipe) to a stream which applies
+# backpressure. It must implement `_identify` (see VarietyQueue for usage) and
+# `_next` to generate a new item.
+#
+# NOTE: In the case that the `_next` call fails, it still MUST invoke the
+# callback with an empty array.
+class VarietyStream
+
+  constructor: (@lowWatermark) ->
+
+  _identify: (item) ->
+    throw Error('VarietyStream._identify not implemented')
+
+  _next: (callback) ->
+    throw Error('VarietyStream._next not implemented')
+
+  # Pipe this stream to another and return that stream. The stream this pipes to
+  # should apply some backpressure, or this will not be able to try to pick
+  # unique values.
+  pipe: (stream) =>
+    queue   = new VarietyQueue(@_identify)
+    reading = false
+    writing = false
+
+    tick = =>
+      reading = @_readToQueue reading, queue, ->
+        reading = false
+        tick()
+
+      writing = @_writeToStream writing, queue, stream, ->
+        writing = false
+        tick()
+
+    tick()
+    return stream
+
+  # If needed, prompt a new read and return the new reading state. If the state
+  # is currently reading, this will immediately return true. If teh number of
+  # items in the buffer are above the low water mark, it will return false (not
+  # reading). Otherwise, it will kick off a new read and set reading to true.
+  _readToQueue: (reading, queue, callback) ->
+    if reading then return true
+    if queue.size() >= @lowWatermark then return false
+
+    @_next (items) =>
+      queue.push(it) for it in items
+      callback()
+    return true
+
+  # If the attached stream is available to be written to, invoke it with the
+  # next best value popped from the queue. Invoke the callback once that value
+  # has been written.
+  _writeToStream: (writing, queue, stream, callback) ->
+    if writing then return true
+
+    value = queue.pop()
+    unless value? then return false
+
+    stream.write(value, callback)
+    return true
+
+
+module.exports = VarietyStream

--- a/test/variety_pipe_spec.coffee
+++ b/test/variety_pipe_spec.coffee
@@ -1,0 +1,103 @@
+require './test_case'
+
+sinon       = require 'sinon'
+{Transform} = require 'stream'
+{expect}    = require 'chai'
+
+VarietyStream = require '../src/variety_stream'
+
+
+describe 'Variety Pipe', ->
+
+  beforeEach ->
+    @next = sinon.stub()
+    @stream = new VarietyStream(5)
+    @stream._identify = (x) -> x
+    @stream._next = @next
+
+  context 'when reading the queue', ->
+
+    context 'when currently reading', ->
+
+      beforeEach ->
+        @readState = @stream._readToQueue(true, null, null)
+
+      it 'should leave read state true', ->
+        expect(@readState).to.be.true
+
+      it 'should not prompt a read', ->
+        expect(@next).to.not.have.been.called
+
+    context 'when above the LWM', ->
+
+      beforeEach ->
+        @queue     = size: sinon.stub().returns(10)
+        @readState = @stream._readToQueue(false, @queue, null)
+
+      it 'should check the size', ->
+        expect(@queue.size).to.have.been.called
+
+      it 'should not prompt a read', ->
+        expect(@next).to.not.have.been.called
+
+      it 'should set read state to false', ->
+        expect(@readState).to.be.false
+
+    context 'when below LWM', ->
+
+      beforeEach ->
+        @queue = size: sinon.stub().returns(3)
+
+      it 'should check the size', ->
+        @stream._readToQueue(false, @queue, null)
+        expect(@queue.size).to.have.been.called
+
+      it 'should prompt a read', ->
+        @stream._readToQueue(false, @queue, null)
+        expect(@next).to.have.been.called
+
+      it 'should set read state to true', ->
+        rs = @stream._readToQueue(false, @queue, null)
+        expect(rs).to.be.true
+
+  context 'when writing to the stream', ->
+
+    beforeEach ->
+      @dst = write: sinon.spy()
+
+    context 'when already writing', ->
+
+      beforeEach ->
+        @writeState = @stream._writeToStream(true, null, @dst)
+
+      it 'should leave write state true', ->
+        expect(@writeState).to.be.true
+
+      it 'should not write', ->
+        expect(@dst.write).to.not.have.been.called
+
+    context 'with no value to pop', ->
+
+      beforeEach ->
+        @queue = pop: sinon.stub().returns(null)
+        @writeState = @stream._writeToStream(false, @queue, @dst)
+
+      it 'should attempt to pop a value', ->
+        expect(@queue.pop).to.have.been.called
+
+      it 'should set write state to false', ->
+        expect(@writeState).to.be.false
+
+      it 'should not write', ->
+        expect(@dst.write).to.not.have.been.called
+
+    context 'with a value to pop', ->
+      beforeEach ->
+        @queue = pop: sinon.stub().returns('Party time!')
+        @writeState = @stream._writeToStream(false, @queue, @dst)
+
+      it 'should transition to writing', ->
+        expect(@writeState).to.be.true
+
+      it 'should write the value to the dst stream', ->
+        expect(@dst.write).to.have.been.calledWith('Party time!')

--- a/test/variety_queue_spec.coffee
+++ b/test/variety_queue_spec.coffee
@@ -1,0 +1,69 @@
+require './test_case'
+
+{expect} = require 'chai'
+
+VarietyQueue = require '../src/variety_queue'
+
+
+describe 'Variety Queue', ->
+
+  beforeEach ->
+    @queue = new VarietyQueue()
+
+  context 'when empty', ->
+
+    it 'should have size 0', ->
+      expect(@queue.size()).to.equal 0
+
+    it 'should pop undefined', ->
+      expect(@queue.pop()).to.be.undefined
+
+  context 'with one item', ->
+
+    beforeEach ->
+      @queue.push(1)
+
+    it 'should have size 1', ->
+      expect(@queue.size()).to.equal 1
+
+    it 'should pop that item', ->
+      expect(@queue.pop()).to.equal 1
+
+    it 'should have no items after popping', ->
+      @queue.pop()
+
+      expect(@queue.size()).to.equal 0
+      expect(@queue.pop()).to.be.undefined
+
+  context 'with multiple equal items', ->
+
+    beforeEach ->
+      @queue.identify = (x) -> x.id
+      @queue.push(id: '666', index: 0)
+      @queue.push(id: '666', index: 1)
+      @queue.push(id: '666', index: 2)
+
+    it 'should be FIFO ordered', ->
+      expect(@queue.pop().index).to.equal 0
+      expect(@queue.pop().index).to.equal 1
+      expect(@queue.pop().index).to.equal 2
+
+  context 'with multiple unequal items', ->
+
+    beforeEach ->
+      @queue.identify = (x) -> x.id
+      @queue.push(id: 'dog', index: 0)
+      @queue.push(id: 'dog', index: 1)
+      @queue.push(id: 'cat', index: 2)
+      @queue.push(id: 'cat', index: 3)
+
+    it 'should consider recently added items older', ->
+      expect(@queue._timeSinceLastPop['dog']).to.equal 0
+      expect(@queue._timeSinceLastPop['cat']).to.equal 1
+
+    it 'should re-order for variety', ->
+      expect(@queue.pop().index).to.equal 2 # 1st cat
+      expect(@queue.pop().index).to.equal 0 # 1st dog
+      expect(@queue.pop().index).to.equal 3 # 2nd cat
+      expect(@queue.pop().index).to.equal 1 # 2nd dog
+      expect(@queue.pop()).to.be.undefined


### PR DESCRIPTION
Added a new primitive, `VarietyQueue` which which can have values `push`ed to
it, and for each `pop`d value, it will make a localized best-effort to return
something it hasn't returned recently.

Building from that is the `VarietyStream` which once told how to generate new
values and compare equality, will feed semi-unique values into a piped stream.

Finally, added a `VariedAdStream` which works very similar to the current
`AdStream`, but uses the tools above. After watching it play for half an hour or
so, it appears to now show duplicates.

`AdCache` has been taken out of the pipeline for the reasons outlined below

Notes:
- The interaction between the AdStream and AdCache was downloading far more
  advertisements than the `queueSize` config value.
- `AdCache`, for reasons still to be determined, was re-ordering ads that passed
  through it.