### PR TITLE
VBID-3732 - Ad serving doesn't recover from a connection problem.

### DIFF
--- a/src/ajax.coffee
+++ b/src/ajax.coffee
@@ -40,6 +40,8 @@ class XMLHttpAjax extends Ajax
       else
         deferred.reject(e)
 
+    xhr.onerror = deferred.reject
+
     xhr.open(method, url, true)
     xhr.send(options.data)
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,7 @@
 AdCache             = require './ad_cache'
 AdRequest           = require './ad_request'
 AdStream            = require './ad_stream'
+VariedAdStream      = require './varied_ad_stream'
 App                 = require './app'
 Player              = require './player'
 ProofOfPlay         = require './proof_of_play'
@@ -15,4 +16,5 @@ module.exports = {
   Player
   ProofOfPlay
   XMLHttpAjax
+  VariedAdStream
 }

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -41,7 +41,11 @@ class VariedAdStream extends VarietyStream
 
     error = (e) =>
       @_log.write name: 'AdStream', message: "request error #{JSON.stringify(e)}"
-      callback([])
+      cb = ->
+        callback([])
+      # error was most likely due to an internet problem. backoff a bit in
+      # order not to flood the console with error messages.
+      setTimeout cb, 1000
 
     @_adRequest.fetch().then(success).catch(error).done()
 


### PR DESCRIPTION
XHR errors were being swallowed, which would eventually break the VarietyStream's tick() loop.

Also, export VariedAdStream to let Cortex apps use it.