### PR TITLE
ProofOfPlay should call stream callback on exceptions as well.

### DIFF
--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -33,9 +33,15 @@ class ProofOfPlay extends Transform
     if @_wasDisplayed(ad)
       @confirm(ad).then (response) =>
         @_process(response, callback)
+      .catch (err) =>
+        @log.write name: 'ProofOfPlay', message: 'confirm failed', meta: ad
+        callback()
     else
       @expire(ad).then (response) =>
         @_process(response, callback)
+      .catch (err) =>
+        @log.write name: 'ProofOfPlay', message: 'expire failed', meta: ad
+        callback()
 
   _wasDisplayed: (ad) ->
     ad.html5player?.was_played

--- a/test/proof_of_play_spec.coffee
+++ b/test/proof_of_play_spec.coffee
@@ -84,7 +84,7 @@ describe 'ProofOfPlay', ->
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         reject()
 
-    it 'should leave the PoP in the internal buffer', (done) ->
+    it 'should drop the PoP request', (done) ->
       ad =
         id: 'some-id'
         proof_of_play_url: @popUrl
@@ -92,7 +92,7 @@ describe 'ProofOfPlay', ->
           was_played: true
 
       verify = =>
-        expect(@pop._writableState).to.have.length 1
+        expect(@pop._writableState).to.have.length 0
         done()
 
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
@@ -110,7 +110,7 @@ describe 'ProofOfPlay', ->
       @http.match url: @expireUrl, type: 'GET', (req, resolve, reject) =>
         reject()
 
-    it 'should leave the PoP in the internal buffer', (done) ->
+    it 'should drop the PoP request', (done) ->
       ad =
         id: 'some-id'
         expiration_url: @expireUrl
@@ -118,7 +118,7 @@ describe 'ProofOfPlay', ->
           was_played: false
 
       verify = =>
-        expect(@pop._writableState).to.have.length 1
+        expect(@pop._writableState).to.have.length 0
         done()
 
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>


### PR DESCRIPTION
This is related to VBID-3732. As it turned out, we need the same thing
for proof of plays.