### PR TITLE
ProofOfPlay should call stream callback on exceptions as well.

### DIFF
--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -30,7 +30,7 @@ class ProofOfPlay extends Transform
       data: JSON.stringify(display_time: ad.display_time)
 
   _transform: (ad, encoding, callback) ->
-    write = ->
+    write = =>
       @write ad
     if @_wasDisplayed(ad)
       @confirm(ad).then (response) =>
@@ -42,7 +42,7 @@ class ProofOfPlay extends Transform
         # HTTP status code. We need to drop the PoP request on server errors.
         if e?.currentTarget?.status == 0
           @log.write name: 'ProofOfPlay', message: 'confirm failed, adding back to the queue.', meta: ad
-          setTimeout(write.bind(@), 5000)
+          setTimeout(write, 5000)
         else
           @log.write name: 'ProofOfPlay', message: 'confirm failed, dropping the request.', meta: ad
     else
@@ -52,7 +52,7 @@ class ProofOfPlay extends Transform
         callback()
         if e?.currentTarget?.status == 0
           @log.write name: 'ProofOfPlay', message: 'expire failed, adding back to the queue.', meta: ad
-          setTimeout(write.bind(@), 5000)
+          setTimeout(write, 5000)
         else
           @log.write name: 'ProofOfPlay', message: 'expire failed, dropping the request.', meta: ad
 

--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -41,10 +41,10 @@ class ProofOfPlay extends Transform
         # flag is set, status code will be 0. Otherwise, status will be set to
         # HTTP status code. We need to drop the PoP request on server errors.
         if e?.currentTarget?.status == 0
-          @log.write name: 'ProofOfPlay', message: 'expire failed, adding back to the queue.', meta: ad
+          @log.write name: 'ProofOfPlay', message: 'confirm failed, adding back to the queue.', meta: ad
           setTimeout(write.bind(@), 5000)
         else
-          @log.write name: 'ProofOfPlay', message: 'expire failed, dropping the request.', meta: ad
+          @log.write name: 'ProofOfPlay', message: 'confirm failed, dropping the request.', meta: ad
     else
       @expire(ad).then (response) =>
         @_process(response, callback)

--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -30,18 +30,22 @@ class ProofOfPlay extends Transform
       data: JSON.stringify(display_time: ad.display_time)
 
   _transform: (ad, encoding, callback) ->
+    write = ->
+      @write ad
     if @_wasDisplayed(ad)
       @confirm(ad).then (response) =>
         @_process(response, callback)
       .catch (err) =>
         @log.write name: 'ProofOfPlay', message: 'confirm failed', meta: ad
         callback()
+        setTimeout(write.bind(@), 1000)
     else
       @expire(ad).then (response) =>
         @_process(response, callback)
       .catch (err) =>
         @log.write name: 'ProofOfPlay', message: 'expire failed', meta: ad
         callback()
+        setTimeout(write.bind(@), 1000)
 
   _wasDisplayed: (ad) ->
     ad.html5player?.was_played

--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -33,9 +33,15 @@ class ProofOfPlay extends Transform
     if @_wasDisplayed(ad)
       @confirm(ad).then (response) =>
         @_process(response, callback)
+      .catch (err) =>
+        @log.write name: 'ProofOfPlay', message: 'confirm failed', meta: ad
+        callback()
     else
       @expire(ad).then (response) =>
         @_process(response, callback)
+      .catch (err) =>
+        @log.write name: 'ProofOfPlay', message: 'expire failed', meta: ad
+        callback()
 
   _wasDisplayed: (ad) ->
     ad.html5player?.was_played

--- a/test/proof_of_play_spec.coffee
+++ b/test/proof_of_play_spec.coffee
@@ -84,7 +84,7 @@ describe 'ProofOfPlay', ->
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         reject()
 
-    it 'should leave the PoP in the internal buffer', (done) ->
+    it 'should drop the PoP request', (done) ->
       ad =
         id: 'some-id'
         proof_of_play_url: @popUrl
@@ -92,7 +92,7 @@ describe 'ProofOfPlay', ->
           was_played: true
 
       verify = =>
-        expect(@pop._writableState).to.have.length 1
+        expect(@pop._writableState).to.have.length 0
         done()
 
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
@@ -110,7 +110,7 @@ describe 'ProofOfPlay', ->
       @http.match url: @expireUrl, type: 'GET', (req, resolve, reject) =>
         reject()
 
-    it 'should leave the PoP in the internal buffer', (done) ->
+    it 'should drop the PoP request', (done) ->
       ad =
         id: 'some-id'
         expiration_url: @expireUrl
@@ -118,7 +118,7 @@ describe 'ProofOfPlay', ->
           was_played: false
 
       verify = =>
-        expect(@pop._writableState).to.have.length 1
+        expect(@pop._writableState).to.have.length 0
         done()
 
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>

--- a/test/proof_of_play_spec.coffee
+++ b/test/proof_of_play_spec.coffee
@@ -80,25 +80,27 @@ describe 'ProofOfPlay', ->
   context 'when a PoP request fails', ->
 
     beforeEach ->
+      @clock = sinon.useFakeTimers()
       @popUrl = 'http://pop.example.com/played?v=2'
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         reject()
 
-    it 'should drop the PoP request', (done) ->
+    afterEach ->
+      @clock.restore()
+
+    it 'should leave the PoP in the internal buffer', (done) ->
       ad =
         id: 'some-id'
         proof_of_play_url: @popUrl
         html5player:
           was_played: true
 
-      verify = =>
-        expect(@pop._writableState).to.have.length 0
-        done()
-
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         expect(@pop._writableState).to.have.length 1
         reject({})
-        setTimeout verify, 1
+        @clock.tick(2000)
+        expect(@pop._writableState).to.have.length 1
+        done()
 
       expect(@pop._writableState).to.have.length 0
       @pop.write(ad)
@@ -106,25 +108,27 @@ describe 'ProofOfPlay', ->
   context 'when PoP expire fails', ->
 
     beforeEach ->
+      @clock = sinon.useFakeTimers()
       @expireUrl = 'http://pop.example.com/expire?v=2'
       @http.match url: @expireUrl, type: 'GET', (req, resolve, reject) =>
         reject()
 
-    it 'should drop the PoP request', (done) ->
+    afterEach ->
+      @clock.restore()
+
+    it 'should leave the PoP in the internal buffer', (done) ->
       ad =
         id: 'some-id'
         expiration_url: @expireUrl
         html5player:
           was_played: false
 
-      verify = =>
-        expect(@pop._writableState).to.have.length 0
-        done()
-
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         expect(@pop._writableState).to.have.length 1
         reject({})
-        setTimeout verify, 1
+        @clock.tick(2000)
+        expect(@pop._writableState).to.have.length 1
+        done()
 
       expect(@pop._writableState).to.have.length 0
       @pop.write(ad)

--- a/test/proof_of_play_spec.coffee
+++ b/test/proof_of_play_spec.coffee
@@ -80,13 +80,9 @@ describe 'ProofOfPlay', ->
   context 'when a PoP request fails', ->
 
     beforeEach ->
-      @clock = sinon.useFakeTimers()
       @popUrl = 'http://pop.example.com/played?v=2'
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         reject()
-
-    afterEach ->
-      @clock.restore()
 
     it 'should leave the PoP in the internal buffer', (done) ->
       ad =
@@ -95,12 +91,14 @@ describe 'ProofOfPlay', ->
         html5player:
           was_played: true
 
-      @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
+      verify = =>
+        expect(@pop._writableState).to.have.length 0
+        done()
+
+      @http.match {url: @popUrl, type: 'GET'}, (req, resolve, reject) =>
         expect(@pop._writableState).to.have.length 1
         reject({})
-        @clock.tick(2000)
-        expect(@pop._writableState).to.have.length 1
-        done()
+        setTimeout verify, 1000
 
       expect(@pop._writableState).to.have.length 0
       @pop.write(ad)
@@ -108,13 +106,9 @@ describe 'ProofOfPlay', ->
   context 'when PoP expire fails', ->
 
     beforeEach ->
-      @clock = sinon.useFakeTimers()
       @expireUrl = 'http://pop.example.com/expire?v=2'
       @http.match url: @expireUrl, type: 'GET', (req, resolve, reject) =>
         reject()
-
-    afterEach ->
-      @clock.restore()
 
     it 'should leave the PoP in the internal buffer', (done) ->
       ad =
@@ -123,12 +117,14 @@ describe 'ProofOfPlay', ->
         html5player:
           was_played: false
 
+      verify = =>
+        expect(@pop._writableState).to.have.length 0
+        done()
+
       @http.match url: @popUrl, type: 'GET', (req, resolve, reject) =>
         expect(@pop._writableState).to.have.length 1
         reject({})
-        @clock.tick(2000)
-        expect(@pop._writableState).to.have.length 1
-        done()
+        setTimeout verify, 1000
 
       expect(@pop._writableState).to.have.length 0
       @pop.write(ad)


### PR DESCRIPTION
This is related to VBID-3732. As it turned out, we need the same thing for proof of plays.

I've also updated the tests. Failed proof of plays should not be kept in internal buffer.