### PR TITLE
VBID-3921 set withCredentials to false

### DIFF
--- a/src/ad_request.coffee
+++ b/src/ad_request.coffee
@@ -14,10 +14,11 @@ class AdRequest
     body = JSON.stringify(@body())
     @log.write name: 'AdRequest', message: "#{@config.url} POST #{body}"
     @http.request
-      type:      'POST'
-      url:       @config.url
-      dataType:  'json'
-      data:      body
+      type:             'POST'
+      url:              @config.url
+      dataType:         'json'
+      data:             body
+      withCredentials:  false
 
   body: ->
     # number_of_screens is deprecated

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -9,6 +9,7 @@ defaultConfig = {}
 defaultConfig['vistar.api_key']    = '58b68728-11d4-41ed-964a-95dca7b59abd'
 defaultConfig['vistar.network_id'] = 'Ex-f6cCtRcydns8mcQqFWQ'
 defaultConfig['vistar.device_id']  = 'test-device-id'
+defaultConfig['vistar.debug']      = false
 defaultConfig['vistar.url']        =
   'http://dev.api.vistarmedia.com/api/v1/get_ad/json'
 
@@ -38,7 +39,7 @@ window?.Vistar = ->
         latitude:          39.9859241
         longitude:         -75.1299363
         queueSize:         10
-        debug:             false
+        debug:             !!defaultConfig['vistar.debug']
         mimeTypes:         ['image/gif', 'image/jpeg', 'image/png', 'video/webm']
         displayArea: [
           {

--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -16,18 +16,20 @@ class ProofOfPlay extends Transform
     @log.write name: 'ProofOfPlay', message: 'expiring', meta: ad
     url = ad.expiration_url
     @http.request
-      type:      'GET'
-      url:       url
-      dataType:  'json'
+      type:             'GET'
+      url:              url
+      dataType:         'json'
+      withCredentials:  false
 
   confirm: (ad) ->
     @log.write name: 'ProofOfPlay', message: 'confirming', meta: ad
     url = ad.proof_of_play_url
     @http.request
-      type:      'POST'
-      url:       url
-      dataType:  'json'
-      data: JSON.stringify(display_time: ad.display_time)
+      type:             'POST'
+      url:              url
+      dataType:         'json'
+      withCredentials:  false
+      data:             JSON.stringify(display_time:  ad.display_time)
 
   _transform: (ad, encoding, callback) ->
     write = =>


### PR DESCRIPTION
by default the ajax lib sets this to true, which will bomb out in Cortex
on the wildcard'd Access-Control-Allow-Origin