### PR TITLE
QUICKFIX add cpm floor, min/max duration, audio

### DIFF
--- a/src/ad_request.coffee
+++ b/src/ad_request.coffee
@@ -49,6 +49,10 @@ class AdRequest
       throw new Error('must configure a displayArea list')
     for screen in @config.displayArea
       screen.supported_media = @supportedMedia()
+      screen.cpm_floor_cents = @config.cpmFloorCents
+      screen.max_duration    = @config.maxDuration
+      screen.min_duration    = @config.minDuration
+      screen.allow_audio     = @config.allowAudio
       screen
 
   _deviceAttribute: -> [

--- a/test/ad_request_spec.coffee
+++ b/test/ad_request_spec.coffee
@@ -79,6 +79,26 @@ describe 'AdRequest', ->
       expect(displayArea[0].supported_media).to.exist
       expect(displayArea[0].supported_media).to.include 'text/x-injected-test-value'
 
+    it 'should add min_duration to display areas if set', ->
+      displayArea = @request.body().display_area
+      expect(displayArea[0].min_duration).to.exist
+      expect(displayArea[0].min_duration).to.equal 5
+
+    it 'should add max_duration to display areas if set', ->
+      displayArea = @request.body().display_area
+      expect(displayArea[0].max_duration).to.exist
+      expect(displayArea[0].max_duration).to.equal 6
+
+    it 'should add cpm_floor_cents to display areas if set', ->
+      displayArea = @request.body().display_area
+      expect(displayArea[0].cpm_floor_cents).to.exist
+      expect(displayArea[0].cpm_floor_cents).to.equal 600
+
+    it 'should add allow_audio to display areas if set', ->
+      displayArea = @request.body().display_area
+      expect(displayArea[0].allow_audio).to.exist
+      expect(displayArea[0].allow_audio).to.be.true
+
     it 'should have the device_attribute array', ->
       body = @request.body()
       expect(body.device_attribute).to.be.an.instanceOf Array

--- a/test/test_case.coffee
+++ b/test/test_case.coffee
@@ -33,15 +33,16 @@ beforeEach ->
         latitude:          39.9859241
         longitude:         -75.1299363
         queueSize:         32
+        minDuration:       5
+        maxDuration:       6
+        cpmFloorCents:     600
+        allowAudio:        true
         mimeTypes:         ['text/x-injected-test-value']
         displayArea: [
           {
             id:            'display-0'
             width:         1280
             height:        720
-            min_duration:  null
-            max_duration:  null
-            allow_audio:   true
           }
         ]
 


### PR DESCRIPTION
these previously weren't being set on the objects in the display area
list - allow setting them in the main part of the config and be copied
to each display area