### PR TITLE
QUICKFIX - Update asset_url to download response path on success

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author":       "Vistar Media <engineering@vistarmedia.com>",
   "name":         "vistar-html5player",
   "description":  "An HTML 5 Player for Vistar Media assets.",
-  "version":      "1.3.3",
+  "version":      "1.3.4",
   "homepage":     "http://kb.vistarmedia.com/display/sell/HTML5+Player",
   "repository": {
     "type":  "git",

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -35,11 +35,11 @@ class VariedAdStream extends VarietyStream
       if @_config.cacheAssets
         downloads = for ad in ads
           @_download.request(url: ad.asset_url, ttl: assetTTL)
-            .then((path) ->
+            .then (path) ->
               # We need to update the asset_url here so it points to the Cortex
               # (cached) location and not S3 or whatever. Typically the
               # asset_url is what is passed to Cortex#submitView / submitVideo.
-              ad.asset_url = path)
+              ad.asset_url = path
 
         deferred(downloads)
           .then -> callback(ads)

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -36,7 +36,7 @@ class VariedAdStream extends VarietyStream
         downloads = for ad in ads
           @_download.request(url: ad.asset_url, ttl: assetTTL)
             .then (path) ->
-              # We need to update the asset_url here so it points to the Cortex
+              # We need to update the asset_url here so it points to the local
               # (cached) location and not S3 or whatever. Typically the
               # asset_url is what is passed to Cortex#submitView / submitVideo.
               ad.asset_url = path

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -34,7 +34,12 @@ class VariedAdStream extends VarietyStream
 
       if @_config.cacheAssets
         downloads = for ad in ads
-          @_download.request url: ad.asset_url, ttl: assetTTL
+          @_download.request(url: ad.asset_url, ttl: assetTTL)
+            .then((path) ->
+              # We need to update the asset_url here so it points to the Cortex
+              # (cached) location and not S3 or whatever. Typically the
+              # asset_url is what is passed to Cortex#submitView / submitVideo.
+              ad.asset_url = path)
 
         deferred(downloads)
           .then -> callback(ads)


### PR DESCRIPTION
* When download succeeds we update the ad.asset_url to the path provided by the
  download callback. This allows us to later on use the cached location for
  things like Cortex ad-view, etc...