### PR TITLE
QUICKFIX VariedAdStream to only include cached ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# 1.4.0
+
+* Download
+  * inject Logger using correct variable
+  * tests around Cortex API behavior
+  * remove annoying 'download-cache' binding, make it private.  this
+    makes it so every app doesn't have to declare a 'download-cache'
+    binding, even though it might not use it
+* VariedAdStream:
+  * fixed bug with deferred(downloads) call.  should be arguments, not array.
+    was always succeeding even if some asset_url download calls failed.
+  * if only some asset_url download calls succeed, only call `_next` callback
+    with ad objects where the asset download succeeded.  Previously, asset_url
+    would be updated with the cached path when it succeeded and would keep the
+    remote url if downloading the asset_url failed.
+  * for the moment, not going to worry about expiring ads that are not emitted from
+    VariedAdStream
+  * will only included cached ads if config.cacheAssets is true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author":       "Vistar Media <engineering@vistarmedia.com>",
   "name":         "vistar-html5player",
   "description":  "An HTML 5 Player for Vistar Media assets.",
-  "version":      "1.3.5",
+  "version":      "1.4.0",
   "homepage":     "http://kb.vistarmedia.com/display/sell/HTML5+Player",
   "repository": {
     "type":  "git",

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -24,7 +24,6 @@ window?.Vistar = ->
       @bindConstant('navigator').to window.navigator
       @bindConstant('video').to document.querySelector('.player video')
       @bindConstant('image').to document.querySelector('.player img')
-      @bindConstant('download-cache').to {}
       @bindConstant('config').to
         url:               config['vistar.url']
         apiKey:            config['vistar.api_key']
@@ -53,8 +52,6 @@ window?.Vistar = ->
 
   injector = new inject.Injector(new Binder)
 
-  store  = injector.getInstance 'download-cache'
-
   ads    = injector.getInstance VariedAdStream
   player = injector.getInstance Player
   pop    = injector.getInstance ProofOfPlay
@@ -65,7 +62,6 @@ window?.Vistar = ->
     ads:     ads
     player:  player
     pop:     pop
-    store:   store
 
   ads
     .pipe(player)

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -41,9 +41,13 @@ class VariedAdStream extends VarietyStream
               # asset_url is what is passed to Cortex#submitView / submitVideo.
               ad.asset_url = path
 
-        deferred(downloads)
-          .then -> callback(ads)
-          .catch -> callback([])
+        deferred(downloads...)
+          .then ->
+            callback(ads)
+          .catch ->
+            succeeded = (ad for ad, i in ads when not downloads[i].failed)
+            callback(succeeded)
+          .done()
       else
         callback(ads)
 

--- a/test/ad_cache_spec.coffee
+++ b/test/ad_cache_spec.coffee
@@ -43,14 +43,14 @@ describe 'AdCache', ->
     beforeEach ->
       @ad = @getAd()
       @assetUrl = @ad.asset_url
-      @store = @injector.getInstance 'download-cache'
-      @store[@assetUrl] =
+      @cache = @injector.getInstance AdCache
+      @cache.download._cache[@assetUrl] =
         cachedAt:     (new Date).getTime()
         lastSeenAt:   (new Date).getTime()
         dataUrl:      'blob:alreadygotit'
         sizeInBytes:  5000
         mimeType:     'image/png'
-      @cache = @injector.getInstance AdCache
+      @store = @cache.download._cache
 
       @now   = 142460040000
       @clock = sinon.useFakeTimers(@now)

--- a/test/test_case.coffee
+++ b/test/test_case.coffee
@@ -18,7 +18,6 @@ beforeEach ->
         userAgent: "AppleWebKit"
       @bindConstant('video').to document.querySelector('.player video')
       @bindConstant('image').to document.querySelector('.player img')
-      @bindConstant('download-cache').to {}
       @bindConstant('config').to
         url:               'http://test.api.vistarmedia.com/api/v1/get_ad/json'
         apiKey:            'YOUR_API_KEY'

--- a/test/varied_ad_stream_spec.coffee
+++ b/test/varied_ad_stream_spec.coffee
@@ -9,14 +9,14 @@ VariedAdStream  = require '../src/varied_ad_stream'
 describe 'VariedAdStream', ->
 
   beforeEach ->
-    @stream = @injector.getInstance VariedAdStream
+    @sandbox = sinon.sandbox.create()
+    @stream  = @injector.getInstance VariedAdStream
+    @sandbox.useFakeTimers()
+
+  afterEach ->
+    @sandbox.restore()
 
   describe '_next', ->
-    beforeEach ->
-      @clock = sinon.useFakeTimers()
-
-    afterEach ->
-      @clock.restore()
 
     it 'should make an ad request', ->
       fetch = sinon.stub @stream._adRequest, 'fetch', ->
@@ -37,7 +37,7 @@ describe 'VariedAdStream', ->
       cb = sinon.stub()
       @stream._next cb
       expect(cb).to.not.have.been.called
-      @clock.tick(3000)
+      @sandbox.clock.tick(3000)
       expect(cb).to.have.been.calledOnce
 
     it 'should cache assets', ->
@@ -67,3 +67,94 @@ describe 'VariedAdStream', ->
       expect(cb).to.have.been.calledOnce
       expect(cb).to.have.been.calledWith @fixtures.adResponse.advertisement
       expect(download).to.not.have.been.called
+
+    context 'when caching assets', ->
+
+      it 'should set asset_url to the path _download.request resolves with', ->
+        i = 0
+        @sandbox.stub @stream._adRequest, 'fetch', =>
+          d = Deferred()
+          d.resolve(@fixtures.adResponse)
+          d.promise
+        @sandbox.stub @stream._download, 'request', (obj) ->
+          d = Deferred()
+          d.resolve("file:///tmp/local/path-#{++i}.jpg")
+          d.promise
+
+        cb = sinon.spy()
+        @stream._next cb
+        @sandbox.clock.tick(1000)
+
+        expect(cb).to.have.been.calledOnce
+
+        [ads] = cb.lastCall.args
+        expect(ads).to.have.length 2
+        [first, second] = ads
+        expect(first.asset_url).to.equal 'file:///tmp/local/path-1.jpg'
+        expect(second.asset_url).to.equal 'file:///tmp/local/path-2.jpg'
+
+      it 'should call with empty array if all cache calls fail', ->
+        @sandbox.stub @stream._adRequest, 'fetch', =>
+          d = Deferred()
+          d.resolve(@fixtures.adResponse)
+          d.promise
+        @sandbox.stub @stream._download, 'request', (obj) ->
+          d = Deferred()
+          d.reject(new Error('terrible error'))
+          d.promise
+
+        cb = sinon.spy()
+        @stream._next cb
+        @sandbox.clock.tick(1000)
+
+        expect(cb).to.have.been.calledOnce
+
+        [ads] = cb.lastCall.args
+        expect(ads).to.have.length 0
+
+      it 'should call callback with all ads if all cache calls succeed', ->
+        i = 0
+        @sandbox.stub @stream._adRequest, 'fetch', =>
+          d = Deferred()
+          d.resolve(@fixtures.adResponse)
+          d.promise
+        @sandbox.stub @stream._download, 'request', (obj) ->
+          d = Deferred()
+          d.resolve("file:///tmp/local/path-#{++i}.jpg")
+          d.promise
+
+        cb = sinon.spy()
+        @stream._next cb
+        @sandbox.clock.tick(1000)
+
+        expect(cb).to.have.been.calledOnce
+
+        [ads] = cb.lastCall.args
+        expect(ads).to.have.length 2
+
+      context 'when only *some* asset_url downloads succeed', ->
+
+        it 'should call with only ads which succeeded', ->
+          i = 0
+          @sandbox.stub @stream._adRequest, 'fetch', =>
+            d = Deferred()
+            d.resolve(@fixtures.adResponse)
+            d.promise
+          @sandbox.stub @stream._download, 'request', (obj) ->
+            d = Deferred()
+            if i is 0
+              d.resolve("file:///tmp/local/path-#{++i}.jpg")
+            if i is 1
+              d.reject(new Error('terrible error'))
+            d.promise
+
+          cb = sinon.spy()
+          @stream._next cb
+          @sandbox.clock.tick(1000)
+
+          expect(cb).to.have.been.calledOnce
+
+          [ads] = cb.lastCall.args
+          expect(ads).to.have.length 1
+          [first] = ads
+          expect(first.asset_url).to.equal 'file:///tmp/local/path-1.jpg'


### PR DESCRIPTION
will only included cached ads if config.cacheAssets is true

* Download
  * inject Logger using correct variable
  * tests around Cortex API behavior
  * remove annoying 'download-cache' binding, make it private.  this
    makes it so every app doesn't have to declare a 'download-cache'
    binding, even though it might not use it
* VariedAdStream:
  * fixed bug with deferred(downloads) call.  should be arguments, not array.
    was always succeeding even if some asset_url download calls failed.
  * if only some asset_url download calls succeed, only call `_next` callback
    with ad objects where the asset download succeeded.  Previously, asset_url
    would be updated with the cached path when it succeeded and would keep the
    remote url if downloading the asset_url failed.

for the moment, not going to worry about expiring ads that are not emitted from
VariedAdStream