### PR TITLE
Simple health checks for VariedAdStream and ProofOfPlay

### DIFF
--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -3,13 +3,6 @@ Logger      = require './logger'
 {Ajax}      = require 'ajax'
 {Transform} = require('stream')
 
-# PoP stream is unhealthy if there hasn't been any PoP requests in past 3
-# minutes.
-lastPopRequestTimeThreshold = 3 * 60 * 1000
-# PoP stream is unhealthy if there hasn't been any successful PoP requests in
-# past 15 minutes.
-lastSuccessfulPopRequestTimeThreshold = 15 * 60 * 1000
-
 class ProofOfPlay extends Transform
   http:    inject Ajax
   config:  inject 'config'
@@ -18,9 +11,8 @@ class ProofOfPlay extends Transform
   constructor: ->
     super(objectMode: true, highWaterMark: 100)
 
-    @_isRunning = false
-    @_lastPopRequestTime = 0
-    @_lastSuccessfulPopRequestTime = 0
+    @lastRequestTime = 0
+    @lastSuccessfulRequestTime = 0
 
   expire: (ad) ->
     @log.write name: 'ProofOfPlay', message: 'expiring', meta: ad
@@ -42,13 +34,12 @@ class ProofOfPlay extends Transform
       data:             JSON.stringify(display_time:  ad.display_time)
 
   _transform: (ad, encoding, callback) ->
-    @_isRunning = true
-    @_lastPopRequestTime = new Date().getTime()
+    @lastRequestTime = new Date().getTime()
     write = =>
       @write ad
     if @_wasDisplayed(ad)
       @confirm(ad).then (response) =>
-        @_lastSuccessfulPopRequestTime = new Date().getTime()
+        @lastSuccessfulRequestTime = new Date().getTime()
         @_process(response, callback)
       .catch (e) =>
         callback()
@@ -62,7 +53,7 @@ class ProofOfPlay extends Transform
           @log.write name: 'ProofOfPlay', message: 'confirm failed, dropping the request.', meta: ad
     else
       @expire(ad).then (response) =>
-        @_lastSuccessfulPopRequestTime = new Date().getTime()
+        @lastSuccessfulRequestTime = new Date().getTime()
         @_process(response, callback)
       .catch (e) =>
         callback()
@@ -84,29 +75,5 @@ class ProofOfPlay extends Transform
       cb(null, response)
     else
       cb()
-
-  onHealthCheck: ->
-    if not @_isRunning
-      return status: true
-
-    now = new Date().getTime()
-    threshold = @config.healthCheck?.lastPopRequestTimeThreshold ||
-      lastPopRequestTimeThreshold
-    if @_lastPopRequestTime + threshold < now
-      return {
-        status: false
-        reason: "No PoP requests in past #{threshold / (60 * 1000)} minutes"
-      }
-
-    threshold = @config.healthCheck?.lastSuccessfulPopRequestTimeThreshold ||
-      lastSuccessfulPopRequestTimeThreshold
-    if @_lastSuccessfulPopRequestTime + threshold < now
-      return {
-        status: false
-        reason: "No successful PoP requests in past #{threshold / (60 * 1000)} minutes"
-      }
-
-    return status: true
-
 
 module.exports = ProofOfPlay

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -9,13 +9,6 @@ VarietyStream = require './variety_stream'
 
 assetTTL = 6 * 60 * 60 * 1000
 
-# Ad stream is unhealthy if there hasn't been any ad requests in past 3
-# minutes.
-lastAdRequestTimeThreshold = 3 * 60 * 1000
-# Ad stream is unhealthy if there hasn't been any successful ad requests in
-# past 15 minutes.
-lastSuccessfulAdRequestTimeThreshold = 15 * 60 * 1000
-
 class VariedAdStream extends VarietyStream
   _adRequest:  inject AdRequest
   _config:     inject 'config'
@@ -25,9 +18,8 @@ class VariedAdStream extends VarietyStream
   constructor: ->
     super(@_config.queueSize or 16)
 
-    @_isRunning = false
-    @_lastAdRequestTime = 0
-    @_lastSuccessfulAdRequestTime = 0
+    @lastRequestTime = 0
+    @lastSuccessfulRequestTime = 0
 
   # The "unique" identity (in terms of adjacency) for an advertisement will be
   # its creative id. The VarietyStream will attempt to not show the same ads
@@ -36,10 +28,8 @@ class VariedAdStream extends VarietyStream
     ad.creative_id
 
   _next: (callback) ->
-    @_isRunning = true
-
     success = (response) =>
-      @_lastSuccessfulAdRequestTime = new Date().getTime()
+      @lastSuccessfulRequestTime = new Date().getTime()
       ads = response?.advertisement or []
 
       @_log.write name: 'AdStream', message: "Returned #{ads.length} ads"
@@ -71,31 +61,7 @@ class VariedAdStream extends VarietyStream
       # order not to flood the console with error messages.
       setTimeout cb, 1000
 
-    @_lastAdRequestTime = new Date().getTime()
+    @lastRequestTime = new Date().getTime()
     @_adRequest.fetch().then(success).catch(error)
-
-  onHealthCheck: ->
-    if not @_isRunning
-      return status: true
-
-    now = new Date().getTime()
-    threshold = @_config.healthCheck?.lastAdRequestTimeThreshold ||
-      lastAdRequestTimeThreshold
-    if @_lastAdRequestTime + threshold < now
-      return {
-        status: false
-        reason: "No ad requests in past #{threshold / (60 * 1000)} minutes"
-      }
-
-    threshold = @_config.healthCheck?.lastSuccessfulAdRequestTimeThreshold ||
-      lastSuccessfulAdRequestTimeThreshold
-    if @_lastSuccessfulAdRequestTime + threshold < now
-      return {
-        status: false
-        reason: "No successful ad requests in past #{threshold / (60 * 1000)} minutes"
-      }
-
-    return status: true
-
 
 module.exports = VariedAdStream

--- a/test/proof_of_play_spec.coffee
+++ b/test/proof_of_play_spec.coffee
@@ -13,6 +13,96 @@ describe 'ProofOfPlay', ->
     @pop  = @injector.getInstance ProofOfPlay
     @http = @injector.getInstance Ajax
 
+  context 'update health check state', ->
+    beforeEach ->
+      @clock = sinon.useFakeTimers()
+
+    afterEach ->
+      @clock.restore()
+
+    it 'should set the isRunning flag on first request', ->
+      ad =
+        id: 'some-id'
+        expiration_url: 'http://pop.example.com/expire?v=1'
+        html5player:
+          was_played: false
+      expect(@pop._isRunning).to.be.false
+      @pop.write(ad)
+      expect(@pop._isRunning).to.be.true
+
+    it 'should set the last PoP request time on each request', ->
+      ad =
+        id: 'some-id'
+        expiration_url: 'http://pop.example.com/expire?v=1'
+        html5player:
+          was_played: false
+      expect(@pop._lastPopRequestTime).to.equal 0
+      @clock.tick(500)
+      @pop.write(ad)
+      expect(@pop._lastPopRequestTime).to.equal 500
+
+    it 'should set the last successful PoP request time when confirm succeeds', ->
+      ad =
+        id: 'some-id'
+        display_time: 1420824124
+        proof_of_play_url: 'http://pop.example.com/pop?v=1'
+        html5player:
+          was_played: true
+
+      @http.match url: ad.proof_of_play_url, type: 'POST', (req, promise) =>
+        expect(JSON.parse(req.data).display_time).to.equal 1420824124
+        promise.resolve @fixtures.popResponse
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 0
+      @clock.tick(500)
+      @pop.write(ad)
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 500
+
+    it 'should not set the last successful PoP request time when confirm fails', ->
+      ad =
+        id: 'some-id'
+        display_time: 1420824124
+        proof_of_play_url: 'http://pop.example.com/pop?v=1'
+        html5player:
+          was_played: true
+
+      @http.match url: ad.proof_of_play_url, type: 'POST', (req, promise) =>
+        expect(JSON.parse(req.data).display_time).to.equal 1420824124
+        promise.reject()
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 0
+      @clock.tick(500)
+      @pop.write(ad)
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 0
+
+    it 'should set the last successful PoP request time when expire succeeds', ->
+      ad =
+        id: 'some-id'
+        expiration_url: 'http://pop.example.com/expire?v=1'
+        html5player:
+          was_played: false
+
+      @http.match url: ad.expiration_url, type: 'GET', (req, promise) =>
+        promise.resolve @fixtures.expireResponse
+
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 0
+      @clock.tick(500)
+      @pop.write(ad)
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 500
+
+    it 'should not set the last successful PoP request time when expire fails', ->
+      ad =
+        id: 'some-id'
+        expiration_url: 'http://pop.example.com/expire?v=1'
+        html5player:
+          was_played: false
+
+      @http.match url: ad.expiration_url, type: 'GET', (req, promise) =>
+        promise.reject()
+
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 0
+      @clock.tick(500)
+      @pop.write(ad)
+      expect(@pop._lastSuccessfulPopRequestTime).to.equal 0
+
   it 'should not fill the _readableState.buffer if not piped to anything', ->
     ad =
       id: 'some-id'
@@ -213,3 +303,66 @@ describe 'ProofOfPlay', ->
 
         @pop.confirm(ad).then(verify)
 
+  describe 'onHealthCheck', ->
+    beforeEach ->
+      @clock = sinon.useFakeTimers()
+
+    afterEach ->
+      @clock.restore()
+
+    it 'should succeed if the stream has not started yet', ->
+      res = @pop.onHealthCheck()
+      expect(res.status).to.be.true
+
+    it 'should fail when last pop request time exceeds the threshold', ->
+      ad =
+        id: 'some-id'
+        expiration_url: 'http://pop.example.com/expire?v=1'
+        html5player:
+          was_played: false
+      @pop.write(ad)
+      @clock.tick 500
+      res = @pop.onHealthCheck()
+      expect(res.status).to.be.true
+      @clock.tick 3 * 60 * 1000
+      res = @pop.onHealthCheck()
+      expect(res.status).to.be.false
+      expect(res.reason).to.match /No PoP requests/
+
+    it 'should fail when last successful PoP request time exceeds the threshold', ->
+      ad =
+        id: 'some-id'
+        display_time: 1420824124
+        proof_of_play_url: 'http://pop.example.com/pop?v=1'
+        html5player:
+          was_played: true
+
+      firstCall = true
+      @http.match url: ad.proof_of_play_url, type: 'POST', (req, promise) =>
+        expect(JSON.parse(req.data).display_time).to.equal 1420824124
+        if firstCall
+          promise.resolve @fixtures.popResponse
+          firstCall = false
+        else
+          promise.reject()
+
+      @pop.write(ad)
+      @clock.tick 500
+      res = @pop.onHealthCheck()
+      expect(res.status).to.be.true
+      @clock.tick 15 * 60 * 1000
+      @pop.write(ad)
+      res = @pop.onHealthCheck()
+      expect(res.status).to.be.false
+      expect(res.reason).to.match /No successful PoP requests/
+
+    it 'should succeed when everything is alright', ->
+      ad =
+        id: 'some-id'
+        expiration_url: 'http://pop.example.com/expire?v=1'
+        html5player:
+          was_played: false
+      @pop.write(ad)
+      @clock.tick 500
+      res = @pop.onHealthCheck()
+      expect(res.status).to.be.true

--- a/test/varied_ad_stream_spec.coffee
+++ b/test/varied_ad_stream_spec.coffee
@@ -18,6 +18,27 @@ describe 'VariedAdStream', ->
 
   describe '_next', ->
 
+    it 'should set the isRunning flag', ->
+      expect(@stream._isRunning).to.be.false
+      @stream._next ->
+      expect(@stream._isRunning).to.be.true
+
+    it 'should set last ad request time', ->
+      expect(@stream._lastAdRequestTime).to.equal 0
+      @sandbox.clock.tick 500
+      @stream._next ->
+      expect(@stream._lastAdRequestTime).to.equal 500
+
+    it 'should set last successful ad request time when fetch succeeds', ->
+      fetch = sinon.stub @stream._adRequest, 'fetch', ->
+        d = Deferred()
+        d.resolve()
+        d.promise
+      expect(@stream._lastSuccessfulAdRequestTime).to.equal 0
+      @sandbox.clock.tick 500
+      @stream._next ->
+      expect(@stream._lastSuccessfulAdRequestTime).to.equal 500
+
     it 'should make an ad request', ->
       fetch = sinon.stub @stream._adRequest, 'fetch', ->
         d = Deferred()
@@ -158,3 +179,44 @@ describe 'VariedAdStream', ->
           expect(ads).to.have.length 1
           [first] = ads
           expect(first.asset_url).to.equal 'file:///tmp/local/path-1.jpg'
+
+  describe 'onHealthCheck', ->
+    it 'should succeed if the stream has not started yet', ->
+      res = @stream.onHealthCheck()
+      expect(res.status).to.be.true
+
+    it 'should fail when last ad request time exceeds the threshold', ->
+      @stream._next ->
+      @sandbox.clock.tick 500
+      res = @stream.onHealthCheck()
+      expect(res.status).to.be.true
+      @sandbox.clock.tick 3 * 60 * 1000
+      res = @stream.onHealthCheck()
+      expect(res.status).to.be.false
+      expect(res.reason).to.match /No ad requests/
+
+    it 'should fail when last successful ad request time exceeds the threshold', ->
+      firstCall = true
+      @sandbox.stub @stream._adRequest, 'fetch', =>
+        d = Deferred()
+        if firstCall
+          d.resolve()
+          firstCall = false
+        else
+          d.reject()
+        d.promise
+      @stream._next ->
+      @sandbox.clock.tick 500
+      res = @stream.onHealthCheck()
+      expect(res.status).to.be.true
+      @sandbox.clock.tick 15 * 60 * 1000
+      @stream._next ->
+      res = @stream.onHealthCheck()
+      expect(res.status).to.be.false
+      expect(res.reason).to.match /No successful ad requests/
+
+    it 'should succeed when everything is alright', ->
+      @stream._next ->
+      @sandbox.clock.tick 500
+      res = @stream.onHealthCheck()
+      expect(res.status).to.be.true


### PR DESCRIPTION
Current health checks:
- There must be at least one ad request in past 3 minutes.
- There must be at least one successful ad request in past 15 minutes.
  Getting an ad response back is considered a success.
- There must be at least one PoP request in past 3 minutes.
- There must be at least on successful PoP request in past 15 minutes.
  Both expire and confirm requests count as a success.