### PR TITLE
Save original asset url when assets are cached

### DIFF
--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -36,6 +36,11 @@ class VariedAdStream extends VarietyStream
         downloads = for ad in ads
           @_download.request(url: ad.asset_url, ttl: assetTTL)
             .then (path) ->
+              # Save the original asset url to let Cortex apps use it for
+              # reporting purposes. Until we have a better alternative in ad
+              # response, asset url is the only sensible piece we can share
+              # with end users.
+              ad.original_asset_url = ad.asset_url
               # We need to update the asset_url here so it points to the local
               # (cached) location and not S3 or whatever. Typically the
               # asset_url is what is passed to Cortex#submitView / submitVideo.

--- a/test/varied_ad_stream_spec.coffee
+++ b/test/varied_ad_stream_spec.coffee
@@ -71,6 +71,8 @@ describe 'VariedAdStream', ->
     context 'when caching assets', ->
 
       it 'should set asset_url to the path _download.request resolves with', ->
+        org_asset_url_1 = @fixtures.adResponse.advertisement[0].asset_url
+        org_asset_url_2 = @fixtures.adResponse.advertisement[1].asset_url
         i = 0
         @sandbox.stub @stream._adRequest, 'fetch', =>
           d = Deferred()
@@ -90,7 +92,9 @@ describe 'VariedAdStream', ->
         [ads] = cb.lastCall.args
         expect(ads).to.have.length 2
         [first, second] = ads
+        expect(first.original_asset_url).to.equal org_asset_url_1
         expect(first.asset_url).to.equal 'file:///tmp/local/path-1.jpg'
+        expect(second.original_asset_url).to.equal org_asset_url_2
         expect(second.asset_url).to.equal 'file:///tmp/local/path-2.jpg'
 
       it 'should call with empty array if all cache calls fail', ->


### PR DESCRIPTION
Original asset urls will get used as view labels in Cortex apps.