### PR TITLE
Initialize request times with current time

### DIFF
--- a/src/proof_of_play.coffee
+++ b/src/proof_of_play.coffee
@@ -11,8 +11,8 @@ class ProofOfPlay extends Transform
   constructor: ->
     super(objectMode: true, highWaterMark: 100)
 
-    @lastRequestTime = 0
-    @lastSuccessfulRequestTime = 0
+    @lastRequestTime = new Date().getTime()
+    @lastSuccessfulRequestTime = new Date().getTime()
 
   expire: (ad) ->
     @log.write name: 'ProofOfPlay', message: 'expiring', meta: ad

--- a/src/varied_ad_stream.coffee
+++ b/src/varied_ad_stream.coffee
@@ -18,8 +18,8 @@ class VariedAdStream extends VarietyStream
   constructor: ->
     super(@_config.queueSize or 16)
 
-    @lastRequestTime = 0
-    @lastSuccessfulRequestTime = 0
+    @lastRequestTime = new Date().getTime()
+    @lastSuccessfulRequestTime = new Date().getTime()
 
   # The "unique" identity (in terms of adjacency) for an advertisement will be
   # its creative id. The VarietyStream will attempt to not show the same ads

--- a/test/proof_of_play_spec.coffee
+++ b/test/proof_of_play_spec.coffee
@@ -15,7 +15,10 @@ describe 'ProofOfPlay', ->
 
   context 'update health check state', ->
     beforeEach ->
-      @clock = sinon.useFakeTimers()
+      @now = new Date().getTime()
+      @clock = sinon.useFakeTimers(@now)
+      # we need a new instance to make sure @pop uses the fake timers.
+      @pop  = @injector.getInstance ProofOfPlay
 
     afterEach ->
       @clock.restore()
@@ -26,10 +29,10 @@ describe 'ProofOfPlay', ->
         expiration_url: 'http://pop.example.com/expire?v=1'
         html5player:
           was_played: false
-      expect(@pop.lastRequestTime).to.equal 0
+      expect(@pop.lastRequestTime).to.equal @now
       @clock.tick(500)
       @pop.write(ad)
-      expect(@pop.lastRequestTime).to.equal 500
+      expect(@pop.lastRequestTime).to.equal @now + 500
 
     it 'should set the last successful PoP request time when confirm succeeds', ->
       ad =
@@ -42,10 +45,10 @@ describe 'ProofOfPlay', ->
       @http.match url: ad.proof_of_play_url, type: 'POST', (req, promise) =>
         expect(JSON.parse(req.data).display_time).to.equal 1420824124
         promise.resolve @fixtures.popResponse
-      expect(@pop.lastSuccessfulRequestTime).to.equal 0
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now
       @clock.tick(500)
       @pop.write(ad)
-      expect(@pop.lastSuccessfulRequestTime).to.equal 500
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now + 500
 
     it 'should not set the last successful PoP request time when confirm fails', ->
       ad =
@@ -58,10 +61,10 @@ describe 'ProofOfPlay', ->
       @http.match url: ad.proof_of_play_url, type: 'POST', (req, promise) =>
         expect(JSON.parse(req.data).display_time).to.equal 1420824124
         promise.reject()
-      expect(@pop.lastSuccessfulRequestTime).to.equal 0
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now
       @clock.tick(500)
       @pop.write(ad)
-      expect(@pop.lastSuccessfulRequestTime).to.equal 0
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now
 
     it 'should set the last successful PoP request time when expire succeeds', ->
       ad =
@@ -73,10 +76,10 @@ describe 'ProofOfPlay', ->
       @http.match url: ad.expiration_url, type: 'GET', (req, promise) =>
         promise.resolve @fixtures.expireResponse
 
-      expect(@pop.lastSuccessfulRequestTime).to.equal 0
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now
       @clock.tick(500)
       @pop.write(ad)
-      expect(@pop.lastSuccessfulRequestTime).to.equal 500
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now + 500
 
     it 'should not set the last successful PoP request time when expire fails', ->
       ad =
@@ -88,10 +91,10 @@ describe 'ProofOfPlay', ->
       @http.match url: ad.expiration_url, type: 'GET', (req, promise) =>
         promise.reject()
 
-      expect(@pop.lastSuccessfulRequestTime).to.equal 0
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now
       @clock.tick(500)
       @pop.write(ad)
-      expect(@pop.lastSuccessfulRequestTime).to.equal 0
+      expect(@pop.lastSuccessfulRequestTime).to.equal @now
 
   it 'should not fill the _readableState.buffer if not piped to anything', ->
     ad =

--- a/test/varied_ad_stream_spec.coffee
+++ b/test/varied_ad_stream_spec.coffee
@@ -10,8 +10,9 @@ describe 'VariedAdStream', ->
 
   beforeEach ->
     @sandbox = sinon.sandbox.create()
+    @now = new Date().getTime()
+    @sandbox.useFakeTimers(@now)
     @stream  = @injector.getInstance VariedAdStream
-    @sandbox.useFakeTimers()
 
   afterEach ->
     @sandbox.restore()
@@ -19,20 +20,20 @@ describe 'VariedAdStream', ->
   describe '_next', ->
 
     it 'should set last ad request time', ->
-      expect(@stream.lastRequestTime).to.equal 0
+      expect(@stream.lastRequestTime).to.equal @now
       @sandbox.clock.tick 500
       @stream._next ->
-      expect(@stream.lastRequestTime).to.equal 500
+      expect(@stream.lastRequestTime).to.equal @now + 500
 
     it 'should set last successful ad request time when fetch succeeds', ->
       fetch = sinon.stub @stream._adRequest, 'fetch', ->
         d = Deferred()
         d.resolve()
         d.promise
-      expect(@stream.lastSuccessfulRequestTime).to.equal 0
+      expect(@stream.lastSuccessfulRequestTime).to.equal @now
       @sandbox.clock.tick 500
       @stream._next ->
-      expect(@stream.lastSuccessfulRequestTime).to.equal 500
+      expect(@stream.lastSuccessfulRequestTime).to.equal @now + 500
 
     it 'should make an ad request', ->
       fetch = sinon.stub @stream._adRequest, 'fetch', ->


### PR DESCRIPTION
It is possible for a Cortex application to get a health check request
before it gets a chance to start the ad flow. Those early health checks
will fail since request times are set to 0 initially.